### PR TITLE
Use Google Cloud Storage as CDN for list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+auth.json
 node_modules
 newrelic_agent.log

--- a/index.js
+++ b/index.js
@@ -1,0 +1,64 @@
+'use strict';
+if (process.env.NEW_RELIC_ENABLED) {
+  require('newrelic');
+}
+
+/* env Variables */
+var nodeEnv = process.env.NODE_ENV || 'development';
+var envDev = nodeEnv === 'development';
+var npmListKeyword = process.env.NPM_LIST_KEYWORD || 'yeoman-generator';
+var apiLimit = process.env.NPM_LIST_LIMIT || (envDev ? 100 : 5000);
+var updateInterval = process.env.UPDATE_INTERVAL_IN_SECONDS || 3610;
+var projectId = process.env.GCLOUD_PROJECT_ID || 'yo-gen-list';
+var bucket = process.env.GCLOUD_BUCKET || 'yeoman-generator-list';
+var keyFilename = process.env.GCLOUD_KEYFILENAME;
+var log = process.env.LOGGER || console;
+
+var fs = require('fs');
+var gcloud = require('gcloud');
+var q = require('q');
+var pluginCache = require('./plugin-cache')
+
+var gconfig = {
+  projectId: projectId
+};
+if (keyFilename) {
+  gconfig.keyFilename = keyFilename;
+}
+var bucket = gcloud(gconfig).storage().bucket(bucket)
+
+/* Plugin Cache operations */
+var Plugins = new pluginCache(npmListKeyword, apiLimit);
+var update = function () {
+  Plugins.update().finally(function () {
+    var file = bucket.file('cache.json');
+    Plugins.getCacheStream()
+    .pipe(file.createWriteStream({
+      gzip: true,
+      metadata: {
+        contentType: 'application/json',
+        cacheControl: 'max-age=3600',
+        metadata: {
+          'ETag': Plugins.getETag()
+        }
+      }
+    }))
+    .on('error', function(err) {
+      log.error('Error publishing the list: ', err);
+    })
+    .on('finish', function () {
+      log.info('Pushed cache to CDN');
+      file.makePublic(function (err) {
+        if (err) {
+          log.error('Error updating the published cache metadata: ', err);
+        }
+        else {
+          log.info('Updated published list metadata');
+        }
+      });
+    });
+
+    setTimeout(update, updateInterval * 1000);
+  });
+};
+update();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "connect": "^3.4.0",
     "connect-timeout": "^1.4.0",
     "errorhandler": "^1.3.0",
+    "gcloud": "^0.23.0",
     "gh-got": "^2.0.0",
     "github-url-to-object": "^1.5.2",
     "got": "^4.2.0",


### PR DESCRIPTION
This turns this more into a cron job type thing that compiles the list
and then pushes it to Google Cloud Storage so sites/3rd parties/yo-cli
can pull it from there.

I didn't remove the server stuff yet so if we wanted to, we could run this side by side with the existing solutions.

@stephenplusplus since you are helping with gcloud, want to take a peek at this?